### PR TITLE
Stop event propogation on the click event

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -70,11 +70,7 @@
 
         <mat-nav-list>
             <pxb-info-list-item *ngFor="let fruit of fruits" (click)="toggleFruit(fruit)" [chevron]="true">
-                <mat-checkbox icon
-                    [checked]="selectedFruits.has(fruit)"
-                    (change)="toggleFruit(fruit)"
-                    color="primary"
-                ></mat-checkbox>
+                <mat-checkbox icon [checked]="selectedFruits.has(fruit)" color="primary"></mat-checkbox>
                 <div title>{{ 'FRUITS.' + fruit | translate }}</div>
                 <div subtitle class="list">{{ 'MORE_INFO' | translate }}</div>
             </pxb-info-list-item>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -27,8 +27,10 @@ export class AppComponent {
         this.open = !this.open;
     }
 
-    toggleFruit(fruit: string): void {
+    // Return false to stop event propagation
+    toggleFruit(fruit: string): boolean {
         this.selectedFruits.has(fruit) ? this.selectedFruits.delete(fruit) : this.selectedFruits.add(fruit);
+        return false;
     }
 
     cancelItems(): void {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #18 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Stop the event propogation on the InfoListItem click event so the checkbox is able to be clicked. 
